### PR TITLE
feat(payments): add contribution_id validation to payment callbacks

### DIFF
--- a/src/app/api/webhooks/billplz/callback/route.ts
+++ b/src/app/api/webhooks/billplz/callback/route.ts
@@ -34,6 +34,10 @@ export async function POST(request: NextRequest) {
       x_signature: xSignature
     });
 
+    // Extract contribution_id from query parameters
+    const url = new URL(request.url);
+    const contributionId = url.searchParams.get('contribution_id');
+    
     // Validate required fields
     if (!callbackData.id) {
       console.error('❌ Missing bill ID in callback');
@@ -42,13 +46,22 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-
-    console.log('🔄 Processing callback for bill ID:', callbackData.id);
     
-    // Process the callback
+    if (!contributionId) {
+      console.error('❌ Missing contribution ID in callback URL');
+      return NextResponse.json(
+        { error: 'Missing contribution ID' },
+        { status: 400 }
+      );
+    }
+
+    console.log('🔄 Processing callback for bill ID:', callbackData.id, 'contribution ID:', contributionId);
+    
+    // Process the callback with compound key validation
     const result = await PaymentService.processBillplzCallback(
       callbackData,
-      xSignature
+      xSignature,
+      contributionId
     );
 
     if (!result.success) {

--- a/src/app/api/webhooks/toyyibpay/callback/route.ts
+++ b/src/app/api/webhooks/toyyibpay/callback/route.ts
@@ -20,6 +20,10 @@ export async function POST(request: NextRequest) {
     // Log callback data for debugging
     console.log('📥 ToyyibPay callback data:', callbackData);
 
+    // Extract contribution_id from query parameters
+    const url = new URL(request.url);
+    const contributionId = url.searchParams.get('contribution_id');
+    
     // Validate required fields
     if (!callbackData.billcode) {
       console.error('❌ Missing bill code in callback');
@@ -28,8 +32,16 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
+    
+    if (!contributionId) {
+      console.error('❌ Missing contribution ID in callback URL');
+      return NextResponse.json(
+        { error: 'Missing contribution ID' },
+        { status: 400 }
+      );
+    }
 
-    console.log('🔄 Processing callback for bill code:', callbackData.billcode);
+    console.log('🔄 Processing callback for bill code:', callbackData.billcode, 'contribution ID:', contributionId);
     
     // Convert to proper ToyyibPayCallbackData structure
     const toyyibPayCallbackData = {
@@ -47,9 +59,10 @@ export async function POST(request: NextRequest) {
       hash: callbackData.hash || '',
     };
 
-    // Process the callback
+    // Process the callback with compound key validation
     const result = await PaymentService.processToyyibPayCallback(
-      toyyibPayCallbackData
+      toyyibPayCallbackData,
+      contributionId
     );
 
     if (!result.success) {

--- a/src/lib/payments/payment-service.ts
+++ b/src/lib/payments/payment-service.ts
@@ -125,7 +125,7 @@ export class PaymentService {
 
       // Generate callback and redirect URLs
       const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const callbackUrl = `${baseUrl}/api/webhooks/billplz/callback`;
+      const callbackUrl = `${baseUrl}/api/webhooks/billplz/callback?contribution_id=${request.contributionId}`;
       const redirectUrl = `${baseUrl}/api/webhooks/billplz/redirect`;
 
       // Create bill
@@ -208,7 +208,7 @@ export class PaymentService {
 
       // Generate callback and redirect URLs
       const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
-      const callbackUrl = `${baseUrl}/api/webhooks/toyyibpay/callback`;
+      const callbackUrl = `${baseUrl}/api/webhooks/toyyibpay/callback?contribution_id=${request.contributionId}`;
       const redirectUrl = `${baseUrl}/api/webhooks/toyyibpay/redirect?mosque_id=${request.mosqueId}`;
 
       // Create bill
@@ -309,10 +309,15 @@ export class PaymentService {
         return { success: false, error: 'Missing bill ID' };
       }
       
-      // Simple lookup by bill_id
+      if (!contributionId) {
+        return { success: false, error: 'Missing contribution ID' };
+      }
+      
+      // Compound key lookup using both contribution_id and bill_id for enhanced security
       const { data: contribution, error: contributionError } = await getSupabaseAdmin()
         .from('contributions')
         .select('*')
+        .eq('id', contributionId)
         .eq('bill_id', billId)
         .single();
 
@@ -368,7 +373,8 @@ export class PaymentService {
    * Process ToyyibPay callback
    */
   static async processToyyibPayCallback(
-    callbackData: ToyyibPayCallbackData
+    callbackData: ToyyibPayCallbackData,
+    contributionId: string
   ): Promise<{ success: boolean; error?: string }> {
     try {
      
@@ -379,11 +385,17 @@ export class PaymentService {
         return { success: false, error: 'Missing bill code' };
       }
       
-      // First lookup contribution by bill_id to get mosque_id
-      console.log('🔍 Looking up contribution by bill ID:', billCode);
+      if (!contributionId) {
+        console.error('❌ Missing contribution ID');
+        return { success: false, error: 'Missing contribution ID' };
+      }
+      
+      // Compound key lookup using both contribution_id and bill_id for enhanced security
+      console.log('🔍 Looking up contribution by compound key - ID:', contributionId, 'Bill Code:', billCode);
       const { data: contribution, error: contributionError } = await getSupabaseAdmin()
         .from('contributions')
         .select('*')
+        .eq('id', contributionId)
         .eq('bill_id', billCode)
         .single();
 


### PR DESCRIPTION
Enhance payment callback security by implementing compound key validation using both contribution_id and bill_id. This prevents potential callback spoofing attacks by ensuring the contribution being processed matches the expected bill reference.